### PR TITLE
[fix] Process Channel Errors regardless of status

### DIFF
--- a/src/com/risevision/viewer/client/channel/ChannelConnectionController.java
+++ b/src/com/risevision/viewer/client/channel/ChannelConnectionController.java
@@ -29,7 +29,7 @@ public class ChannelConnectionController extends ChannelConnectionProvider {
 	private static Command channelCommand;
 	private static int state = INITIAL_STATE;
 	private static String updateTicket;
-	
+		
 	private static Timer connectionVerificationTimer = new Timer() {
 		public void run() {
 			state = INACTIVE_STATE;
@@ -118,23 +118,41 @@ public class ChannelConnectionController extends ChannelConnectionProvider {
 //
 //				state = INACTIVE_STATE;				
 //			}
-			else if (message.contains(MESSAGE_ERROR) && state != INACTIVE_STATE) {
-				state = INACTIVE_STATE;
-				
-				String [] tokens = message.split(":");
-				if (tokens.length > 1 && !"401".equals(tokens[1])) {
-				}
-				else {
-					channelToken = "";
-					connectionVerificationTimer.cancel();
-				}
-				
-				connectChannel(REASON_ERROR);
-			}
+//			else if (message.startsWith(MESSAGE_ERROR) && state != INACTIVE_STATE) {
+//				state = INACTIVE_STATE;
+//				
+//				String [] tokens = message.split(":");
+//				if (tokens.length > 1 && !"401".equals(tokens[1])) {
+//				}
+//				else {
+//					channelToken = "";
+//					connectionVerificationTimer.cancel();
+//				}
+//				
+//				connectChannel(REASON_ERROR);
+//			}
 			else {
 				return;
 			}
 			
+			if (channelCommand != null) {
+				channelCommand.execute();
+			}
+		}
+	}
+	
+	// Static JS callback function
+	public static void setChannelError(int code) {
+		if (state != INITIAL_STATE) {
+			state = INACTIVE_STATE;
+			
+			if (code == 401) {
+				channelToken = "";
+				connectionVerificationTimer.cancel();
+			}
+			
+			connectChannel(REASON_ERROR);
+				
 			if (channelCommand != null) {
 				channelCommand.execute();
 			}

--- a/src/com/risevision/viewer/client/channel/ChannelConnectionProvider.java
+++ b/src/com/risevision/viewer/client/channel/ChannelConnectionProvider.java
@@ -42,7 +42,7 @@ public abstract class ChannelConnectionProvider {
 			"}\n" +
 			"function onError(error) {\n" +
 			"	parent.writeToLog('Channel error:' + error.description + ' code=' + error.code);\n" +
-			"	parent.channelMessage('" + MESSAGE_ERROR + ":' + error.code);\n" +
+			"	parent.channelError(error.code);\n" +
 			"}\n" +
 			"function onClose() {\n" +
 			"	parent.writeToLog('Channel closed, attempting to reconnect.');\n" +

--- a/src/com/risevision/viewer/client/data/ViewerDataController.java
+++ b/src/com/risevision/viewer/client/data/ViewerDataController.java
@@ -100,7 +100,7 @@ public class ViewerDataController extends ViewerDataControllerBase {
 //			ViewerDataProvider.retrieveData();
 //		}
 //		else 
-		if (!hasData() && !ChannelConnectionController.isInactive()) {
+		if (hasData() && !ChannelConnectionController.isInactive()) {
 			stopPolling();
 		}
 		else if (!isBlocked()) {

--- a/src/com/risevision/viewer/client/data/ViewerDataParser.java
+++ b/src/com/risevision/viewer/client/data/ViewerDataParser.java
@@ -36,8 +36,8 @@ public class ViewerDataParser {
 	
 	private String tutorialUrl;
 	
-	private int pollInterval = 5;
-	private int pingInterval = 5;
+	private int pollInterval = 30;
+	private int pingInterval = 30;
 	
 	private int blockRemaining = 0;
 	

--- a/src/com/risevision/viewer/client/info/Global.java
+++ b/src/com/risevision/viewer/client/info/Global.java
@@ -7,7 +7,7 @@ package com.risevision.viewer.client.info;
 import java.util.Date;
 
 public class Global {
-	public static final String VIEWER_VERSION = "1-06-035";
+	public static final String VIEWER_VERSION = "1-06-036";
 	
 //	public static final String GADGET_SERVER_URL = "http://rvagadgets.appspot.com/";
 	public static final String GADGET_SERVER_URL = "http://www-open-opensocial.googleusercontent.com/gadgets/ifr";

--- a/src/com/risevision/viewer/client/utils/ViewerHtmlUtils.java
+++ b/src/com/risevision/viewer/client/utils/ViewerHtmlUtils.java
@@ -181,6 +181,9 @@ public class ViewerHtmlUtils {
 		
 		$wnd.channelMessage = 
 		$entry(@com.risevision.viewer.client.channel.ChannelConnectionController::setChannelMessage(Ljava/lang/String;));
+		
+		$wnd.channelError = 
+		$entry(@com.risevision.viewer.client.channel.ChannelConnectionController::setChannelError(I));
 	}-*/;
 
 	public static native void playCommand(String presFrame, String htmlName, boolean show) /*-{

--- a/war/WEB-INF/appengine-web.xml
+++ b/war/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 	<application>rvashow2</application>
-	<version>1-06-035</version>
+	<version>1-06-036</version>
 	
 	<!-- Configure java.util.logging -->
 	<system-properties>


### PR DESCRIPTION
Split out Channel Error in its own function
Process error even in inactive state

Fixed typo with hasData flag: if Viewer has data it should stop polling

Updated default poll and ping interval to 30 minutes