### PR TITLE
Add viewport by default; set width/height if parameters are given

### DIFF
--- a/src/com/risevision/viewer/client/info/Global.java
+++ b/src/com/risevision/viewer/client/info/Global.java
@@ -7,7 +7,7 @@ package com.risevision.viewer.client.info;
 import java.util.Date;
 
 public class Global {
-	public static final String VIEWER_VERSION = "1-06-038";
+	public static final String VIEWER_VERSION = "1-06-039";
 	
 //	public static final String GADGET_SERVER_URL = "http://rvagadgets.appspot.com/";
 	public static final String GADGET_SERVER_URL = "http://www-open-opensocial.googleusercontent.com/gadgets/ifr";

--- a/war/Viewer.html
+++ b/war/Viewer.html
@@ -12,7 +12,32 @@
 <!-- 	<meta property="og:description" content="This is a preview of a Rise Vision Presentation." /> -->
 	<meta name="google" content="notranslate" />
 <!-- 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/> -->
-    <title>Viewer</title>
+  <script>
+    function getUrlVars() {
+      var vars = {};
+      var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi,    
+      function(m,key,value) {
+        vars[key] = value;
+      });
+      return vars;
+    }
+    (function() {
+      var line1 = '';
+      var w = getUrlVars()['vw'];
+      var h = getUrlVars()['vh'];
+      var viewportEnabled = getUrlVars()['viewport'];
+      if (viewportEnabled === 'false') {
+        line1 = '';
+      } else if (w && h) {
+        line1 = '<meta name="viewport" content="width=' + w +', height=' + h + '">'; 
+      } else {
+        line1 = '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">';
+      }
+      document.write(line1);
+    }());
+  </script>
+
+  <title>Viewer</title>
     
 	<link type="text/css" rel="stylesheet" href="../style/viewer.css">
   </head>
@@ -28,25 +53,7 @@
 	<div id="gcfInfo" style="visibility:hidden;">
 		<div>In order to Preview using the Internet Explorer browser, please Install the following:</div>
 		<div id="gcfMissing" style="position:absolute;"></div>
-	</div>
-
-    <script>
-		function getUrlVars() {
-		    var vars = {};
-		    var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi,    
-		    function(m,key,value) {
-		      vars[key] = value;
-		    });
-		    return vars;
-		  }
-		(function() {
-		  var fType = getUrlVars()["viewport"];  
-		  var line1 = '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">';  
-		  if(fType != 'false'){
-		  document.write(line1);
-		  }
-		}());
-	</script>
+	</div> 
     
     <!--                                           -->
     <!-- This script loads your compiled module.   -->

--- a/war/WEB-INF/appengine-web.xml
+++ b/war/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 	<application>rvashow2</application>
-	<version>1-06-038</version>
+	<version>1-06-039</version>
 	
 	<!-- Configure java.util.logging -->
 	<system-properties>


### PR DESCRIPTION
Also if viewport=false parameter is present, don't add anything

Original Commit Message from woneal1983:
I can do without the viewport tag all together on my amazon and google tv apps, but for the new chromium 43 library for some reason has to have the specific height and width in the viewport in order to fix a scaling issue on boxes and sticks. Works right on tablets but not on boxes or sticks. So if you don't want any viewport at all then this new pull request will do what is needed. I also changed the parameters to vh and vw which works better for me. Anyway take a look and see if this fits.