### PR TITLE
Use regexp to strip meta refresh

### DIFF
--- a/src/main/webapp/scripts/viewerScripts.js
+++ b/src/main/webapp/scripts/viewerScripts.js
@@ -291,8 +291,7 @@ function createPresentation(frameName, containerName, width, height, top, left, 
 }
 
 function stripMetaRefresh(html) {
-  html = html.replace("meta http-equiv=\"refresh\"", "meta http-equiv=\"strippedrefresh\"");
-  html = html.replace("meta http-equiv='refresh'", "meta http-equiv='strippedrefresh'");
+  html = html.replace(/meta[ ]+http-equiv=.refresh./gi, 'meta http-equiv="strippedrefresh"');
   return html;
 }
 


### PR DESCRIPTION
Replaces more variations of "meta http-equiv='refresh'