### PR TITLE
Log Display Activated event

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+dependencies:
+  post:
+    - git clone git@github.com:Rise-Vision/private-keys.git
+    - cp private-keys/core/.appcfg_oauth2_tokens_java ~
 checkout:
   post:
     # Update environment depending URLs
@@ -14,9 +18,9 @@ deployment:
   staging:
     branch: /(feature|fix|chore).*/
     commands:
-      - mvn appengine:update -Dappengine.version=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}') -Dappengine.appId=rvaviewer-test <<< $JENKINS_PASS
+      - mvn appengine:update -Dappengine.version=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}') -Dappengine.appId=rvaviewer-test
   production:
     branch: master
     commands:
-      - mvn appengine:update -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%15))) -Dappengine.appId=rvashow2 <<< $JENKINS_PASS
-      - mvn appengine:set_default_version -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%15))) -Dappengine.appId=rvashow2 <<< $JENKINS_PASS
+      - mvn appengine:update -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%15))) -Dappengine.appId=rvashow2
+      - mvn appengine:set_default_version -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%15))) -Dappengine.appId=rvashow2

--- a/pom.xml
+++ b/pom.xml
@@ -90,10 +90,6 @@
         <version>${appengine.api.version}</version>
         <configuration>
           <port>8888</port>
-          <email>jenkins@risevision.com</email>
-          <oauth2>false</oauth2>
-          <noCookies>true</noCookies>
-          <passin>true</passin>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/risevision/viewer/client/ViewerEntryPoint.java
+++ b/src/main/java/com/risevision/viewer/client/ViewerEntryPoint.java
@@ -158,6 +158,11 @@ public class ViewerEntryPoint implements EntryPoint {
 				// init Analytics for Displays and Preview
 				ViewerHtmlUtils.initAnalytics();
 
+				if(isDisplay() && !isEmbed()) {
+					ViewerHtmlUtils.logAppsEvent("Display Activated");
+					ViewerHtmlUtils.trackAnalyticsEvent("Display", "Display Activated", getDisplayId());
+				}
+
 				if (isPreview()) {
 					if (showUi) {
 						ViewerPreviewWidget.getInstance().show();

--- a/src/main/java/com/risevision/viewer/client/utils/ViewerHtmlUtils.java
+++ b/src/main/java/com/risevision/viewer/client/utils/ViewerHtmlUtils.java
@@ -371,5 +371,15 @@ public class ViewerHtmlUtils {
 		try {	
 			$wnd.logExternal(eventName, displayId, version, eventDetails);
 		} catch (err) {}
-	}-*/;	
+	}-*/;
+
+	public static void logAppsEvent(String eventName) {
+		logAppsEventNative(eventName, ViewerEntryPoint.getDisplayId(), ViewerDataController.getItemCompanyId());
+	}
+
+	private static native void logAppsEventNative(String eventName, String displayId, String companyId) /*-{
+		try {
+			$wnd.logAppsEvent(eventName, displayId, companyId);
+		} catch (err) {}
+	}-*/;
 }

--- a/src/main/webapp/scripts/ext-logger.js
+++ b/src/main/webapp/scripts/ext-logger.js
@@ -3,7 +3,7 @@
 // (reproduced in the LICENSE file).
 
 (function() {
-  var EXTERNAL_LOGGER_SERVICE_URL = "https://www.googleapis.com/bigquery/v2/projects/client-side-events/datasets/Viewer_Events/tables/TABLE_ID/insertAll";
+  var EXTERNAL_LOGGER_SERVICE_URL = "https://www.googleapis.com/bigquery/v2/projects/client-side-events/datasets/DATASET_ID/tables/TABLE_ID/insertAll";
 
   var EXTERNAL_LOGGER_REFRESH_URL = "https://www.googleapis.com/oauth2/v3/token?client_id=1088527147109-6q1o2vtihn34292pjt4ckhmhck0rk0o7.apps.googleusercontent.com&client_secret=nlZyrcPLg6oEwO9f9Wfn29Wh&refresh_token=1/xzt4kwzE1H7W9VnKB8cAaCx6zb4Es4nKEoqaYHdTD15IgOrJDtdun6zK6XiATCKT&grant_type=refresh_token";
 
@@ -25,6 +25,39 @@
     ]
   };
 
+  var _getSuffix = function () {
+    var date = new Date();
+    var year = date.getUTCFullYear();
+    var month = date.getUTCMonth() + 1;
+    var day = date.getUTCDate();
+    if (month < 10) {
+      month = "0" + month;
+    }
+    if (day < 10) {
+      day = "0" + day;
+    }
+    return year.toString() + month.toString() + day.toString();
+  };
+
+  var APPS_EVENTS_LOGGER_INSERT_SCHEMA = {
+    "kind": "bigquery#tableDataInsertAllRequest",
+    "skipInvalidRows": false,
+    "ignoreUnknownValues": false,
+    "templateSuffix": _getSuffix(),
+    "rows": [{
+      "insertId": "",
+      "json": {
+        "event": "",
+        "event_details": "",
+        "event_value": 0,
+        "host": "",
+        "ts": 0,
+        "user_id": "",
+        "company_id": ""
+      }
+    }]
+  };
+
   var EXTERNAL_LOGGER_REFRESH_DATE = 0;
   var EXTERNAL_LOGGER_TOKEN = "";
 
@@ -44,8 +77,8 @@
       if (month < 10) {month = "0" + month;}
       if (day < 10) {day = "0" + day;}
 
-      serviceUrl = EXTERNAL_LOGGER_SERVICE_URL.replace
-      ("TABLE_ID", "events" + year + month + day);
+      serviceUrl = EXTERNAL_LOGGER_SERVICE_URL.replace("DATASET_ID","Viewer_Events")
+        .replace("TABLE_ID", "events" + year + month + day);
 
       EXTERNAL_LOGGER_REFRESH_DATE = refreshData.refreshedAt || EXTERNAL_LOGGER_REFRESH_DATE;
       EXTERNAL_LOGGER_TOKEN = refreshData.token || EXTERNAL_LOGGER_TOKEN;
@@ -79,5 +112,35 @@
     xhr.send();
   }
 
+  function logAppsEvent(eventName, displayId, companyId) {
+      if (!eventName) {return;}
+
+      return refreshToken(insertAppsEventWithToken);
+
+      function insertAppsEventWithToken(refreshData) {
+        var insertData = JSON.parse(JSON.stringify(APPS_EVENTS_LOGGER_INSERT_SCHEMA)),
+        serviceUrl;
+
+        serviceUrl = EXTERNAL_LOGGER_SERVICE_URL.replace("DATASET_ID","Apps_Events")
+          .replace("TABLE_ID", "apps_events");
+
+        EXTERNAL_LOGGER_REFRESH_DATE = refreshData.refreshedAt || EXTERNAL_LOGGER_REFRESH_DATE;
+        EXTERNAL_LOGGER_TOKEN = refreshData.token || EXTERNAL_LOGGER_TOKEN;
+
+        insertData.rows[0].insertId = Math.random().toString(36).substr(2).toUpperCase();
+        insertData.rows[0].json.event = eventName;
+        insertData.rows[0].json.event_details = displayId || "";
+        insertData.rows[0].json.company_id = companyId || "";
+        insertData.rows[0].json.ts = new Date().toISOString();
+
+        var xhr = new XMLHttpRequest();
+        xhr.open("POST", serviceUrl, true);
+        xhr.setRequestHeader("Content-Type", "application/json");
+        xhr.setRequestHeader("Authorization", "Bearer " + EXTERNAL_LOGGER_TOKEN);
+        xhr.send(JSON.stringify(insertData));
+      }
+    }
+
   window.logExternal = logExternal;
+  window.logAppsEvent = logAppsEvent;
 }());


### PR DESCRIPTION
- Added `Display Activated` event tracking to BQ and GA
- Update our deploy authentication as Google deprecated the old API we were using.

I think we should queue a card to use BQ Template Tables in  `logExternal()` method as well.

@alex-deaconu  Please review. Thanks! 