### PR TITLE
No longer send Done for PH Timeline failure

### DIFF
--- a/src/main/java/com/risevision/viewer/client/controller/ViewerPlaceholderController.java
+++ b/src/main/java/com/risevision/viewer/client/controller/ViewerPlaceholderController.java
@@ -331,8 +331,11 @@ public class ViewerPlaceholderController {
 				}
 			}
 		}
-		
-		return gadgets.size() == 0 || !placeholder.isVisible() || isPlaying || placeholderDoneCommand == null;
+
+		// returning false doesn't call placeholderDone
+		return placeholderDoneCommand == null || 
+				gadgets.size() == 0 || !placeholder.isVisible() || isPlaying || 
+				(ViewerEntryPoint.isDisplay() && !placeholder.getTimeline().canPlay());
 	}
 	
 	public void playEmptyPlaceholder() {


### PR DESCRIPTION
I've modified the Presentation used in the previous validation to be used for this as well.

To clarify, a Play Until Done placeholder is set to not play in the Placeholder timeline, however the Placeholder should have items in it. Previously (on http://rvaviewer-test.appspot.com) it should generate a stack error. On http://stack-error.rvaviewer-test.appspot.com/ that error should be gone.

@ezequielc please review. Thanks.