### PR TITLE
Check for null or empty duration string

### DIFF
--- a/src/main/java/com/risevision/viewer/client/controller/ViewerPlaceholderController.java
+++ b/src/main/java/com/risevision/viewer/client/controller/ViewerPlaceholderController.java
@@ -129,7 +129,7 @@ public class ViewerPlaceholderController {
 		boolean gadgetReady = false;
 		if (placeholder.getPlaylistItems() != null) {
 			for (PlaylistItemInfo item: placeholder.getPlaylistItems()){
-				if (!item.getDuration().isEmpty() && !(RiseUtils.strToInt(item.getDuration(), 0) < 1)
+				if (!RiseUtils.strIsNullOrEmpty(item.getDuration()) && !(RiseUtils.strToInt(item.getDuration(), 0) < 1)
 						&& (item.getDistributionToAll() || ViewerEntryPoint.checkDistribution(item.getDistribution()))){
 //					setInheritedValues(item);
 					

--- a/src/main/java/com/risevision/viewer/client/controller/ViewerScheduleController.java
+++ b/src/main/java/com/risevision/viewer/client/controller/ViewerScheduleController.java
@@ -114,7 +114,7 @@ public class ViewerScheduleController {
 		// Removes items with blank durations		
 		int itemCount = 0;
 		for (PlaylistItemInfo item: schedule.getPlayListItems()){
-			if (!item.getDuration().isEmpty() && !(RiseUtils.strToInt(item.getDuration(), 0) < 1)){
+			if (!RiseUtils.strIsNullOrEmpty(item.getDuration()) && !(RiseUtils.strToInt(item.getDuration(), 0) < 1)){
 //				setInheritedValues(item);
 		
 				ViewerPresentationController presentation = ViewerPresentationController.getInstance(item, 


### PR DESCRIPTION
Fixes an issue in the Viewer were the `duration` is `null`. Still investigating the reason for the `null` value; however this will allow Item playback.

@ezequielc please review. Thanks.